### PR TITLE
NGSTN-1398 delay followup rebalance

### DIFF
--- a/.github/workflows/coralogix_publish.yml
+++ b/.github/workflows/coralogix_publish.yml
@@ -1,0 +1,25 @@
+name: Coralogix Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: public-runner
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Publish
+        run: |
+          ./gradlew "-PmavenUrl=https://cgx.jfrog.io/artifactory/virtual.sbt.coralogix.net" \
+                    "-PmavenUsername=${{ secrets.ARTIFACTORY_USERNAME }}" \
+                    "-PmavenPassword=${{ secrets.ARTIFACTORY_TOKEN }}" \
+                    publish

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ ext {
   userMaxTestRetryFailures = project.hasProperty('maxTestRetryFailures') ? maxTestRetryFailures.toInteger() : 0
 
   skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
-  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT")
+  shouldSign = false
 
   mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
   mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -401,10 +401,11 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                 // AFTER we've triggered  the revoke callback
                 firstException.compareAndSet(null, rebalanceListenerInvoker.invokePartitionsRevoked(revokedPartitions));
 
+                // NGSTN-1398 Coralogix modification
                 // If revoked any partitions, need to re-join the group afterwards
-                final String fullReason = String.format("need to revoke partitions %s as indicated " +
-                        "by the current assignment and re-join", revokedPartitions);
-                requestRejoin("need to revoke partitions and re-join", fullReason);
+//        final String fullReason = String.format("need to revoke partitions %s as indicated " +
+//          "by the current assignment and re-join", revokedPartitions);
+//        requestRejoin("need to revoke partitions and re-join", fullReason);
             }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ group=org.apache.kafka
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
-version=3.9.0
+version=3.9.0-cx1-SNAPSHOT
 scalaVersion=2.13.14
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 # New version of Swagger 2.2.14 requires minimum JDK 11.

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ group=org.apache.kafka
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
-version=3.9.0-cx1-SNAPSHOT
+version=3.9.0-cx3
 scalaVersion=2.13.14
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 # New version of Swagger 2.2.14 requires minimum JDK 11.

--- a/streams/quickstart/java/pom.xml
+++ b/streams/quickstart/java/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.kafka</groupId>
         <artifactId>streams-quickstart</artifactId>
-        <version>3.9.0-cx1-SNAPSHOT</version>
+        <version>3.9.0-cx3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams/quickstart/java/pom.xml
+++ b/streams/quickstart/java/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.kafka</groupId>
         <artifactId>streams-quickstart</artifactId>
-        <version>3.9.0</version>
+        <version>3.9.0-cx1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>3.9.0</kafka.version>
+        <kafka.version>3.9.0-cx1-SNAPSHOT</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
     </properties>
 

--- a/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
+++ b/streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>3.9.0-cx1-SNAPSHOT</kafka.version>
+        <kafka.version>3.9.0-cx3</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
     </properties>
 

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>3.9.0-cx1-SNAPSHOT</version>
+    <version>3.9.0-cx3</version>
 
     <name>Kafka Streams :: Quickstart</name>
 

--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.apache.kafka</groupId>
     <artifactId>streams-quickstart</artifactId>
     <packaging>pom</packaging>
-    <version>3.9.0</version>
+    <version>3.9.0-cx1-SNAPSHOT</version>
 
     <name>Kafka Streams :: Quickstart</name>
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -846,6 +846,12 @@ public class StreamsConfig extends AbstractConfig {
     private static final String LOG_SUMMARY_INTERVAL_MS_DOC = "This configuration controls the output interval for summary information.\n" +
             "If greater or equal to 0, the summary log will be output according to the set time interval;\n" +
             "If less than 0, summary output is disabled.";
+
+    // Coralogix modification NGSTN-1398
+    @SuppressWarnings("WeakerAccess")
+    public static final String CX_FOLLOWUP_REBALANCE_DELAY_MS_CONFIG = "cx.followup.rebalance.delay.ms";
+    public static final String CX_FOLLOWUP_REBALANCE_DELAY_MS_DOC = "";
+
     /**
      * {@code topology.optimization}
      * @deprecated since 2.7; use {@link #TOPOLOGY_OPTIMIZATION_CONFIG} instead
@@ -1233,7 +1239,13 @@ public class StreamsConfig extends AbstractConfig {
                     Type.LONG,
                     2 * 60 * 1000L,
                     Importance.LOW,
-                    LOG_SUMMARY_INTERVAL_MS_DOC);
+                    LOG_SUMMARY_INTERVAL_MS_DOC)
+            // Coralogix modification NGSTN-1398
+            .define(CX_FOLLOWUP_REBALANCE_DELAY_MS_CONFIG,
+                    Type.LONG,
+                    5 * 1000L,
+                    Importance.MEDIUM,
+                    CX_FOLLOWUP_REBALANCE_DELAY_MS_DOC);
     }
 
     // this is the list of configs for underlying clients

--- a/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/assignment/AssignmentConfigs.java
@@ -34,6 +34,7 @@ public class AssignmentConfigs {
     private final OptionalInt rackAwareTrafficCost;
     private final OptionalInt rackAwareNonOverlapCost;
     private final String rackAwareAssignmentStrategy;
+    private final long followupRebalanceDelayMs;
 
     public static AssignmentConfigs of(final StreamsConfig configs) {
         final long acceptableRecoveryLag = configs.getLong(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG);
@@ -44,6 +45,7 @@ public class AssignmentConfigs {
         final String rackAwareAssignmentStrategy = configs.getString(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG);
         final Integer rackAwareTrafficCost = configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG);
         final Integer rackAwareNonOverlapCost = configs.getInt(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG);
+        final long followupRebalanceDelayMs = configs.getLong(StreamsConfig.CX_FOLLOWUP_REBALANCE_DELAY_MS_CONFIG);
 
         return new AssignmentConfigs(
             acceptableRecoveryLag,
@@ -53,7 +55,37 @@ public class AssignmentConfigs {
             rackAwareAssignmentTags,
             rackAwareTrafficCost != null ? OptionalInt.of(rackAwareTrafficCost) : OptionalInt.empty(),
             rackAwareNonOverlapCost != null ? OptionalInt.of(rackAwareNonOverlapCost) : OptionalInt.empty(),
-            rackAwareAssignmentStrategy
+            rackAwareAssignmentStrategy,
+            followupRebalanceDelayMs
+        );
+    }
+
+    public AssignmentConfigs(final long acceptableRecoveryLag,
+                             final int maxWarmupReplicas,
+                             final int numStandbyReplicas,
+                             final long probingRebalanceIntervalMs,
+                             final List<String> rackAwareAssignmentTags,
+                             final OptionalInt rackAwareTrafficCost,
+                             final OptionalInt rackAwareNonOverlapCost,
+                             final String rackAwareAssignmentStrategy,
+                             final long followupRebalanceDelayMs
+                             ) {
+        this.acceptableRecoveryLag = validated(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, acceptableRecoveryLag);
+        this.maxWarmupReplicas = validated(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, maxWarmupReplicas);
+        this.numStandbyReplicas = validated(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbyReplicas);
+        this.probingRebalanceIntervalMs = validated(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, probingRebalanceIntervalMs);
+        this.rackAwareAssignmentTags = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rackAwareAssignmentTags);
+        this.rackAwareTrafficCost = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG,
+          defaultRackAwareTrafficCost(rackAwareTrafficCost)
+        );
+        this.rackAwareNonOverlapCost = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG,
+          defaultRackAwareNonOverlapCost(rackAwareNonOverlapCost)
+        );
+        this.rackAwareAssignmentStrategy = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG,
+          rackAwareAssignmentStrategy
+        );
+        this.followupRebalanceDelayMs = validated(StreamsConfig.CX_FOLLOWUP_REBALANCE_DELAY_MS_CONFIG,
+          followupRebalanceDelayMs
         );
     }
 
@@ -65,20 +97,8 @@ public class AssignmentConfigs {
                              final OptionalInt rackAwareTrafficCost,
                              final OptionalInt rackAwareNonOverlapCost,
                              final String rackAwareAssignmentStrategy) {
-        this.acceptableRecoveryLag = validated(StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG, acceptableRecoveryLag);
-        this.maxWarmupReplicas = validated(StreamsConfig.MAX_WARMUP_REPLICAS_CONFIG, maxWarmupReplicas);
-        this.numStandbyReplicas = validated(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, numStandbyReplicas);
-        this.probingRebalanceIntervalMs = validated(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, probingRebalanceIntervalMs);
-        this.rackAwareAssignmentTags = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_TAGS_CONFIG, rackAwareAssignmentTags);
-        this.rackAwareTrafficCost = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_TRAFFIC_COST_CONFIG,
-            defaultRackAwareTrafficCost(rackAwareTrafficCost)
-        );
-        this.rackAwareNonOverlapCost = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_NON_OVERLAP_COST_CONFIG,
-            defaultRackAwareNonOverlapCost(rackAwareNonOverlapCost)
-        );
-        this.rackAwareAssignmentStrategy = validated(StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_CONFIG,
-            rackAwareAssignmentStrategy
-        );
+        this(acceptableRecoveryLag, maxWarmupReplicas, numStandbyReplicas, probingRebalanceIntervalMs, rackAwareAssignmentTags,
+          rackAwareTrafficCost, rackAwareNonOverlapCost, rackAwareAssignmentStrategy, 5000);
     }
 
     public AssignmentConfigs(final long acceptableRecoveryLag,
@@ -166,6 +186,14 @@ public class AssignmentConfigs {
         return rackAwareAssignmentStrategy;
     }
 
+    /**
+     * The delay of followup replica
+     * {@link StreamsConfig#CX_FOLLOWUP_REBALANCE_DELAY_MS_CONFIG}
+     */
+    public long followupRebalanceDelayMs() {
+        return followupRebalanceDelayMs;
+    }
+
     private static <T> T validated(final String configKey, final T value) {
         final ConfigDef.Validator validator = StreamsConfig.configDef().configKeys().get(configKey).validator;
         if (validator != null) {
@@ -185,6 +213,7 @@ public class AssignmentConfigs {
                "\n  rackAwareTrafficCost=" + rackAwareTrafficCost +
                "\n  rackAwareNonOverlapCost=" + rackAwareNonOverlapCost +
                "\n  rackAwareAssignmentStrategy=" + rackAwareAssignmentStrategy +
+               "\n  followupRebalanceDelayMs=" + followupRebalanceDelayMs +
                "\n}";
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1564,18 +1564,21 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                                                 final int latestCommonlySupportedVersion,
                                                 final Set<HostInfo> groupHostInfo) {
         if (maybeUpdateSubscriptionVersion(receivedAssignmentMetadataVersion, latestCommonlySupportedVersion)) {
-            log.info("Requested to schedule immediate rebalance due to version probing.");
-            nextScheduledRebalanceMs.set(0L);
+            // Coralogix modification NGSTN-1398
+            log.info("Requested to schedule a rebalance in {}ms due to version probing.", assignmentConfigs.followupRebalanceDelayMs());
+            nextScheduledRebalanceMs.set(time.milliseconds() + assignmentConfigs.followupRebalanceDelayMs());
         } else if (!verifyHostInfo(groupHostInfo)) {
-            log.info("Requested to schedule immediate rebalance to update group with new host endpoint = {}.", userEndPoint);
-            nextScheduledRebalanceMs.set(0L);
+            // Coralogix modification NGSTN-1398
+            log.info("Requested to schedule a rebalance in {}ms to update group with new host endpoint = {}.", assignmentConfigs.followupRebalanceDelayMs(), userEndPoint);
+            nextScheduledRebalanceMs.set(time.milliseconds() + assignmentConfigs.followupRebalanceDelayMs());
         } else if (encodedNextScheduledRebalanceMs == 0L) {
-            log.info("Requested to schedule immediate rebalance for new tasks to be safely revoked from current owner.");
-            nextScheduledRebalanceMs.set(0L);
+            // Coralogix modification NGSTN-1398
+            log.info("Requested to schedule a rebalance in {}ms for new tasks to be safely revoked from current owner.", assignmentConfigs.followupRebalanceDelayMs());
+            nextScheduledRebalanceMs.set(time.milliseconds() + assignmentConfigs.followupRebalanceDelayMs());
         } else if (encodedNextScheduledRebalanceMs < Long.MAX_VALUE) {
             log.info(
-                "Requested to schedule next probing rebalance at {} to try for a more balanced assignment.",
-                Utils.toLogDateTimeFormat(encodedNextScheduledRebalanceMs)
+              "Requested to schedule next probing rebalance at {} to try for a more balanced assignment.",
+              Utils.toLogDateTimeFormat(Math.max(encodedNextScheduledRebalanceMs, assignmentConfigs.followupRebalanceDelayMs()))
             );
             nextScheduledRebalanceMs.set(encodedNextScheduledRebalanceMs);
         } else {

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -22,4 +22,4 @@
 # Instead, in development branches, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 1.0.0-SNAPSHOT, this should be something like "1.0.0.dev0"
-__version__ = '3.9.0'
+__version__ = '3.9.0.cx1.dev0'

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -22,4 +22,4 @@
 # Instead, in development branches, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 1.0.0-SNAPSHOT, this should be something like "1.0.0.dev0"
-__version__ = '3.9.0.cx1.dev0'
+__version__ = '3.9.0.cx3'


### PR DESCRIPTION
* Don't trigger rebalance immediately after revoking partitions
* Delay rebalance after receiving "revoking active" partitions by 5 seconds

This gives members time to SyncGroup while te group is Stable, before staring the followup rebalance.